### PR TITLE
Fix secret token string: remove white space and '\n'

### DIFF
--- a/mlops-template-gitlab/lambda_functions/lambda-seedcode-checkin-gitlab/lambda_function.py
+++ b/mlops-template-gitlab/lambda_functions/lambda-seedcode-checkin-gitlab/lambda_function.py
@@ -48,7 +48,7 @@ def get_secret():
         # Depending on whether the secret is a string or binary, one of these fields will be populated.
         if 'SecretString' in get_secret_value_response:
             secret = get_secret_value_response['SecretString']
-            return secret.split(':')[-1].strip('"}')
+            return secret.split(':')[-1].strip('" "}\n')
         else:
             decoded_binary_secret = base64.b64decode(get_secret_value_response['SecretBinary'])
             return decoded_binary_secret


### PR DESCRIPTION
*Issue #, if available:*
lambda-seedcode-checkin-gitlab lambda_function.py failing due to incorrect secret token string.
*Description of changes:*
Updated string to remove white space and '\n'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
