### PR TITLE
Update setup.py to specify SageMaker SDK version

### DIFF
--- a/mlops-template-gitlab/seedcode/mlops-gitlab-project-seedcode-model-build/setup.py
+++ b/mlops-template-gitlab/seedcode/mlops-gitlab-project-seedcode-model-build/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as f:
     readme = f.read()
 
 
-required_packages = ["sagemaker"]
+required_packages = ["sagemaker==2.78.0"]
 extras = {
     "test": [
         "black",


### PR DESCRIPTION
*Issue #, if available:*
Using latest SDK version build fails. Specifying working `sagemaker==2.78.0`

*Description of changes:*
Update setup.py to specify SageMaker SDK version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
