### PR TITLE
Fixes #15 - Only approved models trigger the deployment pipeline

### DIFF
--- a/mlops-template-gitlab/project.yml
+++ b/mlops-template-gitlab/project.yml
@@ -153,6 +153,8 @@ Resources:
         detail:
           ModelPackageGroupName:
             - !Sub ${SageMakerProjectName}-${SageMakerProjectId}
+          ModelApprovalStatus:
+            - "Approved"
       State: "ENABLED"
       Targets:
         -


### PR DESCRIPTION
This fixes https://github.com/aws-samples/sagemaker-custom-project-templates/issues/15.

Based on the design of `mlops-template-gitlab`, the model deployment pipeline should only be triggered for 'Approved' models.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
