### PR TITLE
temp fix for protobuf package upgrade error

### DIFF
--- a/mlops-template-gitlab/seedcode/mlops-gitlab-project-seedcode-model-build/.gitlab-ci.yml
+++ b/mlops-template-gitlab/seedcode/mlops-gitlab-project-seedcode-model-build/.gitlab-ci.yml
@@ -21,6 +21,7 @@ train-model:
   stage: training
   script: 
       - pip install --upgrade --force-reinstall . "awscli>1.20.30"
+      - export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
       - export PYTHONUNBUFFERED=TRUE
       - export SAGEMAKER_PROJECT_NAME_ID="${SAGEMAKER_PROJECT_NAME}-${SAGEMAKER_PROJECT_ID}"
       - |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

recent release of a new protobuf library causes build pipeline deployment to fail. Setting the `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION` to `python` allows the pipeline to run successfully, albeit potentially slower.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
