### PR TITLE
optionally allow asset publishing

### DIFF
--- a/mlops-multi-account-cdk/mlops-sm-project-template-rt/mlops_sm_project_template_rt/templates/pipeline_constructs/deploy_pipeline_construct.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template-rt/mlops_sm_project_template_rt/templates/pipeline_constructs/deploy_pipeline_construct.py
@@ -45,6 +45,7 @@ class DeployPipelineConstruct(Construct):
         preprod_account: int,
         prod_account: int,
         deployment_region: str,
+        enable_asset_publishing: bool = False, # set to true if you would like to enable an asset publishing stage
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -224,7 +225,12 @@ class DeployPipelineConstruct(Construct):
                 project=cdk_synth_build,
             )
         )
-
+        
+        # optionally: add a stage to publish assets if the code in the deploy repository needs them
+        
+        if enable_asset_publishing:
+            self.enable_asset_publishing(cdk_synth_artifact, deploy_code_pipeline)
+        
         # add a security evaluation stage for cloudformation templates
         security_stage = deploy_code_pipeline.add_stage(stage_name="SecurityEvaluation")
 
@@ -346,3 +352,62 @@ class DeployPipelineConstruct(Construct):
             ),
             targets=[targets.CodePipeline(deploy_code_pipeline)],
         )
+    
+    # publishing assets using cdk-assets, relies on asset manifests being already created by cdk synth
+    def enable_asset_publishing(self, input_artifact, pipeline):
+        
+        asset_publish_role = iam.Role(
+            self,
+            "AssetPublishRole",
+            assumed_by=iam.ServicePrincipal("codebuild.amazonaws.com"),
+            path="/service-role/",
+        )
+
+        asset_publish_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "sts:AssumeRole",
+                ],
+                effect=iam.Effect.ALLOW,
+                resources=[f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:role/cdk-hnb659fds-file-publishing-role-{Aws.ACCOUNT_ID}-{Aws.REGION}"],
+            )
+        )
+
+        assets_publish_project = codebuild.PipelineProject(
+            self,
+            "AssetsPublish",
+            environment=codebuild.BuildEnvironment(
+                build_image=codebuild.LinuxBuildImage.STANDARD_5_0,
+            ),
+            role=asset_publish_role,
+            build_spec=codebuild.BuildSpec.from_object(
+                {
+                    "version": 0.2,
+                    "phases": {
+                        "install": {
+                            "commands": [
+                                "npm install -g cdk-assets@2"
+                            ]
+                            },
+                            "build": {
+                            "commands": [
+                                "cdk-assets --path \"dev.assets.json\" --verbose publish",
+                                "cdk-assets --path \"preprod.assets.json\" --verbose publish",
+                                "cdk-assets --path \"prod.assets.json\" --verbose publish",
+                            ]
+                        }
+                    }
+                }
+            )
+        )
+
+        assets_stage = pipeline.add_stage(stage_name="Assets")
+        assets_stage.add_action(
+            codepipeline_actions.CodeBuildAction(
+                action_name="Assets",
+                input=input_artifact,
+                outputs=[],
+                project=assets_publish_project,
+            )
+        )
+


### PR DESCRIPTION
flag `enable_asset_publishing` is used to control whether to add an optional step to publish cdk assets to s3, this is useful if the target code repository makes use of assets (for example lambda function code as an asset)

Can be further improved by:
- looping over assets manifests (for now the 3 asset manifests for 3 environments are hardcoded) 
- externalising this logic to a separate script/construct to be reusable in any pipeline construct

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
