### PR TITLE
some additional policies for product launch role

### DIFF
--- a/mlops-multi-account-cdk/mlops-sm-project-template-rt/mlops_sm_project_template_rt/service_catalog_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template-rt/mlops_sm_project_template_rt/service_catalog_stack.py
@@ -178,6 +178,29 @@ class ServiceCatalogStack(Stack):
                 resources=[f"arn:aws:sagemaker:*:{Aws.ACCOUNT_ID}:model-package-group/*"],
             ),
         )
+        
+        # allows user to see the created resources in service catalog view
+        products_launch_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["cloudformation:ListStackResources"], 
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    "*"
+                ],
+            ),
+        )
+        
+        # allows updating provisiond products on the fly without reprovisioning
+        # useful for development workd on the template
+        products_launch_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["codebuild:UpdateProject"],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    "*"
+                ],
+            ),
+        )
 
         portfolio = servicecatalog.Portfolio(
             self,


### PR DESCRIPTION
 Added two extra policies to the product launch role:
- allows user to see the created resources in service catalog view
- allows updating provisioned products on the fly without re-provisioning (deleting the provisioned product is a pain)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
