### PR TITLE
Adding sagemaker:AddTags permissions for SM-Gitlab-Example-Launch-Policy

### DIFF
--- a/mlops-template-gitlab/create-mlops-gitlab-product.yaml
+++ b/mlops-template-gitlab/create-mlops-gitlab-product.yaml
@@ -332,6 +332,10 @@ Resources:
                   - 'iam:PassRole'
                 Resource:
                   - !Join ['', ['arn:aws:iam::', !Ref AWS::AccountId, ':role/SM-Gitlab-Example-Use-Role-*']]
+              - Effect: Allow
+                Action:
+                  - 'sagemaker:AddTags'
+                Resource: '*'
       RoleName: !Join ['-', ['SM-Gitlab-Example-Launch-Role', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref 'AWS::StackId']]]]]]
 
   ServiceCatalogProductUseRole:


### PR DESCRIPTION
*Issue #, if available:* Instantiating a new project from the gitlab template currently has a permission error: 

`User: arn:aws:sts::XXXXX:assumed-role/SM-Gitlab-Example-Launch-Role-XXXX/servicecatalog is not authorized to perform: sagemaker:AddTags on resource: arn:aws:sagemaker:XXX:XXXX:code-repository/sm-model-deploy-XXX because no identity-based policy allows the sagemaker:AddTags action (Service: AmazonSageMaker; Status Code: 400; Error Code: AccessDeniedException; Request ID: xxxxxxxx; Proxy: null)`

*Description of changes:* Adding sagemaker:AddTags permissions to SM-Gitlab-Example-Launch-Policy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
