### PR TITLE
Encrypted buckets fixes - unique name of artifact bucket & fix rule for triggering deploy pip…

### DIFF
--- a/encrypted-buckets/project/template.yaml
+++ b/encrypted-buckets/project/template.yaml
@@ -31,7 +31,7 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
-      BucketName: !Sub 'sagemaker-${SageMakerProjectName}-artifacts'
+      BucketName: !Sub 'sagemaker-${SageMakerProjectName}-${SageMakerProjectId}-artifacts'
       BucketEncryption:
         ServerSideEncryptionConfiguration: 
         - ServerSideEncryptionByDefault:
@@ -164,7 +164,7 @@ Resources:
           - SageMaker Model Package State Change
         detail:
           ModelPackageGroupName:
-            - !Sub '${SageMakerProjectName}'
+            - !Sub '${SageMakerProjectName}-${SageMakerProjectId}'
       State: ENABLED
       Targets:
         - Arn: !Join 
@@ -242,7 +242,7 @@ Resources:
           - Name: MODEL_EXECUTION_ROLE_ARN
             Value: !Ref UseRoleArn
           - Name: SOURCE_MODEL_PACKAGE_GROUP_NAME
-            Value: !Sub '${SageMakerProjectName}'
+            Value: !Sub '${SageMakerProjectName}-${SageMakerProjectId}'
           - Name: AWS_REGION
             Value: !Ref 'AWS::Region'
           - Name: EXPORT_TEMPLATE_NAME


### PR DESCRIPTION


*Description of changes:*
Two important fixes:
- artifact bucket that is created in this template should have unique name in other case stack is failing. To make it unique I just added project id to the name of the bucket
- Event rule that should trigger deploy pipeline had different model package name than is created in training pipeline. I changed that name to be the same in train&deploy part.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
