### PR TITLE
Update secrets.tf

### DIFF
--- a/sm-project-tf-gitlab/service-catalog-setup/secrets.tf
+++ b/sm-project-tf-gitlab/service-catalog-setup/secrets.tf
@@ -6,6 +6,7 @@
 resource "aws_secretsmanager_secret" "git_repo_secret" {
   name        = "${local.cmn_res_name}-gitlab-token"
   description = "Secret for ML Gitlab private token"
+  force_destroy = true
 }
 
 resource "aws_secretsmanager_secret_version" "git_repo_secret_version" {
@@ -21,6 +22,7 @@ resource "aws_secretsmanager_secret_version" "git_repo_secret_version" {
 resource "aws_secretsmanager_secret" "git_iam_access_key_secret" {
   name        = "${local.cmn_res_name}-gitlab-iam-access-key"
   description = "Secret for ML Gitlab IAM Access Key"
+  force_destroy = true
 }
 
 resource "aws_secretsmanager_secret_version" "git_iam_access_key_version" {
@@ -36,6 +38,7 @@ resource "aws_secretsmanager_secret_version" "git_iam_access_key_version" {
 resource "aws_secretsmanager_secret" "git_iam_secret_key_secret" {
   name        = "${local.cmn_res_name}-gitlab-iam-secret-key"
   description = "Secret for ML Gitlab IAM Secret Key"
+  force_destroy = true
 }
 
 resource "aws_secretsmanager_secret_version" "git_iam_secret_key_version" {
@@ -52,6 +55,7 @@ resource "aws_secretsmanager_secret_version" "git_iam_secret_key_version" {
 resource "aws_secretsmanager_secret" "gitlab_user_creds" {
   name        = "${local.cmn_res_name}-gitlab-creds"
   description = "Secret for ML Github repo creds"
+  force_destroy = true
 }
 
 resource "aws_secretsmanager_secret_version" "gitlab_user_creds_version" {


### PR DESCRIPTION
Adding the force_destroy argument to delete the AWS secrets forcefully when encountered a roll back. The manual deletion is required if there is the argument is not present.

*Issue #, if available:* Force_destroy argument

*Description of changes:*
Adding the force_destroy argument to delete the AWS secrets forcefully when encountered a roll back. The manual deletion is required if there is the argument is not present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
