### PR TITLE
Modify instance_count and instance_type to use Pipelines's Parameter …

### DIFF
--- a/batch-inference/seedcode/pipelines/batch_inference/pipeline.py
+++ b/batch-inference/seedcode/pipelines/batch_inference/pipeline.py
@@ -92,8 +92,8 @@ def get_pipeline(
     #### SAGEMAKER CONSTRUCTS
     transform = Transformer(
         model_name=model_name,
-        instance_count=1,
-        instance_type='ml.m5.xlarge',
+        instance_count=batch_inference_instance_count,
+        instance_type=batch_inference_instance_type,
         output_path=output_path,
         base_transform_job_name=f"{base_job_prefix}/batch-transform-job",
         max_payload=10,


### PR DESCRIPTION
…in batch-inference/seedcode/pipelines/batch_inference/pipeline.py

*Issue #, if available:*
NA

*Description of changes:*
In [batch-inference/seedcode/pipelines/batch_inference/pipeline.py](https://github.com/aws-samples/sagemaker-custom-project-templates/blob/main/batch-inference/seedcode/pipelines/batch_inference/pipeline.py#L95-L96), instance_count and batch_inference_instance_type does not user pipeline's parameter.
I replaced them with batch_inference_instance_count (ParameterInteger) and batch_inference_instance_type (ParameterString).

```
    #### PARAMETERS
    model_name = ParameterString("ModelName", default_value='${ModelName}')
    batch_inference_instance_count = ParameterInteger("BatchInstanceCount", default_value=1)
    batch_inference_instance_type = ParameterString("BatchInstanceType", default_value='ml.m5.xlarge')
    input_path = ParameterString("InputPath", default_value=f"s3://sagemaker-servicecatalog-seedcode-{region}/dataset/abalone-dataset.csv")
    output_path = ParameterString("OutputPath")

    #### SAGEMAKER CONSTRUCTS
    transform = Transformer(
        model_name=model_name,
        instance_count=1,
        instance_type='ml.m5.xlarge',
        output_path=output_path,
        base_transform_job_name=f"{base_job_prefix}/batch-transform-job",
        max_payload=10,
        accept='text/csv'
    )
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
