### PR TITLE
mlops-multi-account-cdk template: upgrade ruby to 3.2

### DIFF
--- a/mlops-multi-account-cdk/mlops-infra/mlops_infra/pipeline_stack.py
+++ b/mlops-multi-account-cdk/mlops-infra/mlops_infra/pipeline_stack.py
@@ -123,7 +123,7 @@ class PipelineStack(Stack):
                             },
                             "phases": {
                                 "install": {
-                                    "runtime-versions": {"ruby": 3.1},
+                                    "runtime-versions": {"ruby": 3.2},
                                     "commands": [
                                         "export date=`date +%Y-%m-%dT%H:%M:%S.%NZ`",
                                         "echo Installing cfn_nag - `pwd`",


### PR DESCRIPTION
*Issue #, if available:*
Deployment fails because of ruby 3.1 not being available and cdk explicitly requesting the upgrade to 3.2.
*Description of changes:*
Updated the ruby version in "mlops-multi-account-cdk/mlops-infra/mlops_infra/pipeline_stack.py"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
